### PR TITLE
Fix rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,6 @@
             {platform_define, "linux", 'ESCAPE_USING_CDATA_SECTIONS'},
             {platform_define, "linux", 'ESCAPE_USING_CDATA_NIF'},
             {platform_define, "(linux|solaris|freebsd|darwin)", 'HAVE_EXPAT'},
-            {platform_define, "(linux|solaris|freebsd|darwin)", 'HAVE_LIBXML2'},
             {platform_define, "(linux|solaris|freebsd|darwin)", 'HAVE_ZLIB'},
             {platform_define, "(linux|solaris|freebsd|darwin)", 'HAVE_OPENSSL'}
            ]}.
@@ -20,21 +19,22 @@
  [{compile, "make -f ./compile_hook.mk compile"},
   {clean, "make -f ./compile_hook.mk clean"}]}.
 
-{port_envs,
- [{"CFLAGS", "$CFLAGS -I/usr/include/libxml2"},
-  {"LDFLAGS", "$LDFLAGS -module -lei_st -lz -lssl -lcrypto -lxml2 -lexpat"}]}.
+{port_env,
+ [{"LDFLAGS", "$LDFLAGS -module -lei_st -lz -lssl -lcrypto -lexpat"}]}.
 
 {port_specs,
- [{"priv/lib/exmpp_xml_libxml2.so",
-   ["c_src/exmpp_driver.c", "c_src/exmpp_xml.c", "c_src/exmpp_xml_libxml2.c"]}
-  ,{"priv/lib/exmpp_xml_expat.so",
-    ["c_src/exmpp_driver.c", "c_src/exmpp_xml.c", "c_src/exmpp_xml_expat.c"]}
-  ,{"priv/lib/exmpp_stringprep.so",
-    ["c_src/exmpp_driver.c", "c_src/exmpp_stringprep.c"]}
-  ,{"priv/lib/exmpp_zlib.so",
-    ["c_src/exmpp_driver.c", "c_src/exmpp_compress_zlib.c"]}
-  ,{"priv/lib/exmpp_tls_openssl.so",
-    ["c_src/exmpp_driver.o", "c_src/exmpp_tls.o", "c_src/exmpp_tls_openssl.o"]}
-  ]}.
+ [{"priv/lib/exmpp_xml_expat.so",
+      ["c_src/exmpp_driver.c", "c_src/exmpp_xml.c",
+       "c_src/exmpp_xml_expat.c"]},
+  {"priv/lib/exmpp_xml_expat_legacy.so",
+      ["c_src/exmpp_driver.c", "c_src/exmpp_xml.c",
+       "c_src/exmpp_xml_expat_legacy.c"]},
+  {"priv/lib/exmpp_stringprep.so",
+      ["c_src/exmpp_driver.c", "c_src/exmpp_stringprep.c"]},
+  {"priv/lib/exmpp_compress_zlib.so",
+      ["c_src/exmpp_driver.c", "c_src/exmpp_compress_zlib.c"]},
+  {"priv/lib/exmpp_tls_openssl.so",
+      ["c_src/exmpp_driver.c", "c_src/exmpp_tls.c",
+       "c_src/exmpp_tls_openssl.c"]}]}.
 
 {edoc_opts, [{def, [{vsn, "0.9.4-HEAD"}]}, {packages, false}]}.


### PR DESCRIPTION
- Do no require libxml2 parser: it has only experimental support
  and anyway we shouldn't require both (expat always will be used).
- Fix filenames.
